### PR TITLE
Correct name for cyclododecanamine

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The challenge culminates with a [joint D3R/SAMPL workshop](https://drugdesigndat
 
 ### Changes not yet in a release
 - Correct outdated CB8 sodium phosphate buffer concentration which appeared in an image (it was already correct in the text).
+- Update due dates
+- Include input files converted to other formats (from Michael Shirts)
+- Fix a compound name for one CB8 compound, SMILES NC1CCCCCCCCCCC1, which is cyclododecanamine; this should have no functional importance (as all of the files here were generated from SMILES) unless someone re-generated inputs from the compound names (which likely would have been difficult).
+- Correct a pKa microstate
+- Fix a submission template issue
 
 ## Challenge Overview
 (This is reproduced from the [SAMPL6 Website](https://drugdesigndata.org/about/sampl6))

--- a/host_guest/Isaacs_SAMPL6_guests.smi
+++ b/host_guest/Isaacs_SAMPL6_guests.smi
@@ -6,7 +6,7 @@ O(c1c(OCC[N+](CC)(CC)CC)cccc1OCC[N+](CC)(CC)CC)CC[N+](CC)(CC)CC gallamine trieth
 CC1(C)[C@@]2(C)CC[C@@H]1C[C@@H]2N (1R,2S,4R)-1,7,7-trimethylbicyclo[2.2.1]heptan-2-amine
 NC1CCCCCC1 cycloheptanamine
 NC1CCCCCCC1 cyclooctanamine
-NC1CCCCCCCCCCC1 cyclodecanamine
+NC1CCCCCCCCCCC1 cyclododecanamine
 N[C@@]12C[C@@H]3C[C@H](C2)C[C@H]1C3 (2R,3as,5S,6as)-hexahydro-2,5-methanopentalen-3a(1H)-amine
 N[C@]12C[C@@H]3C[C@H](C1)C[C@@](C2)(O)C3 (1s,3r,5R,7S)-3-aminoadamantan-1-ol
 N[C@H]1CC[C@H](N)CC1 cyclohexane diamine


### PR DESCRIPTION
Corrects #34 -- chemical name for cyclododecanamine listed incorrectly in CB8 smiles file (but input files all are correct).

Also updates README to note changes since last release, in preparation for doing a new release. 