### PR TITLE
Update "Uploading your predictions" section of logP_challenge_instructions.md

### DIFF
--- a/logP_challenge_instructions.md
+++ b/logP_challenge_instructions.md
@@ -196,9 +196,15 @@ If you would like to submit predictions from multiple methods, you should fill a
 
 ## Uploading your predictions
 
-D3R is currently outfitting the SAMPL6 page with the ability to accept your uploaded predictions. As soon as this is ready, you may upload your predictions. If you want to upload predictions of more than one method, each must be uploaded as a separate file. Please use the template provided to create the submission files, as the predictions will be parsed and analyzed with automated scripts. Please include all predictions made with the same method in one file.
+D3R website SAMPL6 page is now ready to accept your uploaded predictions. You may upload your predictions as soon as you are ready and until the submission deadline. If you want to upload predictions of more than one method, each must be uploaded as a separate file. Please use the template provided to create the submission files, as the predictions will be parsed and analyzed with automated scripts. Please include all predictions made with the same method in one file.  
 
-**All submissions are required to contain logP predictions of all 11 compounds. Incomplete submissions - such as for a subset of compounds - will not be accepted.** 
+**All submissions are required to contain logP predictions of all 11 compounds. Incomplete submissions - such as for a subset of compounds - will not be accepted.**   
+
+To submit your predictions go to the [D3R SAMPL6 webpage](https://drugdesigndata.org/about/sampl6), log in to your account, and select the **logP Prediction** challenge on the left menu. Then click **Submissions** on the green ribbon.  
+
+Add your file(s) using **Submit Your Data** section. Submitted files will be checked by a validation script for conforming to submission template rules. After clicking **Start upload**, please pay attention to any error message that may show up at the bottom of the submission page. When your files are successfully submitted you should be able to see them listed in the upper **Manage Your Data** section, even after you refresh the webpage or re-log in to your account.  
+
+Please check that **Manage Your Data** section includes a complete list of your submission files.  
 
 ## SAMPL6 Part II Workshops
 


### PR DESCRIPTION
These are the same instructions I have added to `logP_challenge_instructions.md` for announcing D3R SAMPL page is ready to accept submissions in `logP_submissions_open` branch but were reverted accidentally. 

This PR ensures all necessary instructions about uploading files is available in `logP_challenge_instructions.md`.