### PR TITLE
Add virtual workshop details to logP challenge instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The SAMPL project was recently funded by the National Institutes of Health, for 
 
 ### Changes not yet in a release
 - [Molecular statistics analysis](./physical_properties/logP/analysis/analysis_outputs/MolecularStatisticsTables) added for SAMPL6 Part II logP Challenge. This analysis was performed to indicate logP values of which molecules of SAMPL6 logP Challenge set were more difficult for methods to predict accurately.
+- Information about SAMPL6 Virtual Workshop and JCAMD special issue for log *P* challenge were added to [logP_challenge_instructions.md](./logP_challenge_instructions.md).
 
 ## Challenge Overview
 (This is reproduced from the [SAMPL6 Website](https://drugdesigndata.org/about/sampl6))

--- a/logP_challenge_instructions.md
+++ b/logP_challenge_instructions.md
@@ -210,6 +210,38 @@ Please check that **Manage Your Data** section includes a complete list of your 
 
 There will be two opportunities for participants to discuss their results.  **SAMPL6 log *P* Challenge Virtual Workshop** will meet on **May 16, 2019**, for sharing methods and discussion of preliminary results.  All participants are also invited to the third in-person **D3R and SAMPL Workshop** which is scheduled for **August 22-23, 2019**, in San Diego to discuss further findings and lessons-learned, as wells as D3R and SAMPL projects more broadly. Note that the workshop is right before the ACS National Meeting in San Diego with the theme of “Chemistry of Water” .
 
+
+### 1. The SAMPL6 Log *P* Challenge Virtual Workshop
+
+We have a virtual pre-workshop on the SAMPL6 LogP challenge on Thursday, May 16, beginning at 7 am US Pacific time.  
+
+#### Overview/Purpose
+
+The purpose of this workshop is to go over a preliminary evaluation of results, begin considering analysis and lessons learned, and nucleate opportunities for follow up and additional discussion. Part of the goal is to facilitate discussion so that participants can work *together* to maximize lessons learned in the lead up to the August in-person D3R/SAMPL workshop and the JCAMD special issue.
+We hope this early workshop will result in additional follow-up afterwards.
+
+#### Agenda
+
+A tentative agenda for this workshop is (all times US Pacific (PDT; UTC-7)):
+- **7-7:10 am**: *Welcome, introductions, and purpose*; David Mobley (UCI)
+- **7:10-7:50 am**: *Experiments and overview of results*, Mehtap Isik (MSKCC); 30 minute talk + 10 minutes of questions/discussion.
+- **7:50-8:05 am**: Andrew Paluch (Miami University, Ohio)
+- **8:05-8:35 am**: Christoph Loschen (Cosmologic), *COSMO-RS based predictions for the SAMPL6 logP challenge*; 20 minute talk + 10 minutes of questions/discussion
+- **8:35-8:55 am**: Nicolas Tielker (TU Dortmund); 12 minute talk + 8 minutes of questions/discussion
+- **8:55-9:15 am**: Esteban Vohringer-Martinez (Univ. Concepción); 15 minute talk + 5 minutes of questions/discussion.
+- **9:15 am-9:25 am**: Alexey Nikitin; 5 minute talk + 5 minutes of discussion.
+- **9:25-10 am**: Discussion and follow up opportunities.
+
+#### Connection details
+
+This is a Zoom meeting/workshop. You may join using [this link](https://uchealth.zoom.us/j/687748918). You should download the software in advance if you do not already have it. If you plan on attending and are not a participant, please ensure your video is turned off and your microphone is muted to improve the experience for other participants.
+Dial-in options for audio are also available; contact David Mobley if you need to dial in.
+
+### 2. The 2019 D3R/SAMPL Joint Workshop
+
+The next [face-to-face workshop](https://drugdesigndata.org/about/d3r-2019-workshop) is Aug. 22-23, 2019 in San Diego, joint with D3R.
+Participation is relatively limited but we are checking on whether virtual attendance is a possibility.
+
 ## Files provided
 
 - `/physical_properties/logP/molecule_ID_and_SMILES.csv` - CSV file that indicates SAMPL6 logP challenge molecule IDs and isomeric SMILES.

--- a/logP_challenge_instructions.md
+++ b/logP_challenge_instructions.md
@@ -242,6 +242,21 @@ Dial-in options for audio are also available; contact David Mobley if you need t
 The next [face-to-face workshop](https://drugdesigndata.org/about/d3r-2019-workshop) is Aug. 22-23, 2019 in San Diego, joint with D3R.
 Participation is relatively limited but we are checking on whether virtual attendance is a possibility.
 
+## Publishing in the special issue of JCAMD 
+
+In coordination with Terry Stouch, we are planning a special issue of *J. Comp. Aided Mol. Design* (JCAMD) focused on the SAMPL6 log *P* challenge. All participants are welcome to submit manuscripts. The submission deadline for this is Sept. 15, 2019, with submissions opening prior to our August 2019 workshop for those who would like to submit early. As usual, papers are expected to appear online in advance of their publication in the special issue as soon as they are ready unless otherwise requested.
+
+### Review criteria for special issue
+In general, review criteria for SAMPL special issues are modestly different than for typical journal publications. Specifically, since these are blind prediction challenges, the community feeling has been that participants should be entitled to report what they did even if the reviewers might feel that it was ill advised, not particularly novel/exciting, or had modest had technical problems. However, papers must still:
+
+- fairly report their results, without overselling or giving an unwarranted sales pitch
+- clearly identify and discuss any technical flaws reviews or others might have highlighted
+- provide adequate details (and supporting materials) so that others can reproduce the work
+and otherwise ensure that they meet the standards of the journal.
+
+Additionally, as a particular focus of SAMPL is on lessons learned, authors are urged to pay devote careful attention to highlighting what was learned from participation and how it might be of benefit to the field or to others employing similar methodologies.
+
+
 ## Files provided
 
 - `/physical_properties/logP/molecule_ID_and_SMILES.csv` - CSV file that indicates SAMPL6 logP challenge molecule IDs and isomeric SMILES.


### PR DESCRIPTION
Virtual workshop information and agenda were added to logP challenge instructions.

If available I can also add presentation titles to the agenda and more information about the special journal issue.